### PR TITLE
Run "rustdoc --test README.md" directly instead of using skeptic.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 repository = "https://github.com/im-0/log4rs-syslog"
 documentation = "https://docs.rs/crate/log4rs-syslog"
 readme = "README.md"
-build = "build.rs"
 
 [badges]
 travis-ci = { repository = "im-0/log4rs-syslog", branch = "master" }
@@ -29,10 +28,8 @@ log4rs = { version = "*", default_features = false }
 serde = { version = "*", default_features = false, optional = true }
 serde_derive = { version = "*", default_features = false, optional = true }
 
-[build-dependencies]
-skeptic = "*"
-
 [dev-dependencies]
+glob = "*"
 log4rs = "*"
 tempfile = "*"
-skeptic = "*"
+which = "*"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There is no proper way to fix this limitations while using libc's interface.
 ## Usage
 
 Add this to your Cargo.toml:
+
 ```toml
 [dependencies]
 log4rs-syslog = "3.0"
@@ -42,6 +43,7 @@ log4rs-syslog = "3.0"
 ### Initialization based on configuration file
 
 Example configuration file:
+
 ```yaml
 appenders:
   syslog:
@@ -59,6 +61,7 @@ root:
 ```
 
 Example code:
+
 ```rust,no_run
 #[macro_use]
 extern crate log;
@@ -87,6 +90,7 @@ fn main() {
 ### Manual initialization
 
 Example code:
+
 ```rust,no_run
 #[macro_use]
 extern crate log;

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    // generates doc tests for `README.md`.
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,37 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));
+extern crate glob;
+extern crate which;
+
+#[test]
+fn readme_test() {
+    let rustdoc = which::which("rustdoc").unwrap();
+
+    let readme = std::path::Path::new(file!()).canonicalize().unwrap();
+    let readme = readme.parent().unwrap().parent().unwrap().join("README.md");
+    let readme = readme.to_str().unwrap();
+
+    let deps = std::path::Path::new(&std::env::current_exe().unwrap())
+        .canonicalize()
+        .unwrap();
+    let deps = deps.parent().unwrap();
+
+    let liblog = glob::glob(deps.join("liblog-*.rlib").to_str().unwrap())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    let liblog = liblog.to_str().unwrap();
+
+    let mut cmd = std::process::Command::new(rustdoc);
+    cmd.arg("--verbose")
+        .args(&["--library-path", deps.to_str().unwrap()])
+        .args(&["--extern", &format!("log={}", liblog)])
+        .arg("--test")
+        .arg(&readme);
+
+    let result = cmd.spawn()
+        .expect("Failed to spawn rustdoc process")
+        .wait()
+        .expect("Failed to run rustdoc process");
+
+    assert!(result.success(), "Failed to run rustdoc tests on README.md");
+}

--- a/travis-script
+++ b/travis-script
@@ -22,6 +22,9 @@ elif [ "${1}" = "script" ]; then
     if is_nightly; then
         cargo bench --features unstable
     fi
+
+    # tests/skeptic.rs will fail without this.
+    cargo clean
 else
     printf "Unknown command: %s\n" "${1}" >&2
     exit 1


### PR DESCRIPTION
Should fix #16.

See also budziq/rust-skeptic#60.